### PR TITLE
Fix loose typo to lose

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run it you need <a href="http://www.libsdl.org/" target="_blank">SDL2</a>
 ## How to play
 
 Use the arrow keys to control the diver.
-When you loose or win, hit `Enter` to restart.
+When you lose or win, hit `Enter` to restart.
 You can also exit with `Esc`.
 
 ![alt tag](https://raw.githubusercontent.com/bvssvni/rust-snake/master/sea-snake.png)

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -3,6 +3,6 @@
 pub enum GameState {
     Play,
     Win,
-    Loose
+    Lose
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,9 +14,9 @@ pub static YOU_WIN_TEXT: &'static str = "you win";
 pub static YOU_WIN_TEXT_COLOR: [f32, ..4] = GREEN;
 pub static YOU_WIN_POS: [f64, ..2] = [-0.42, 0.1];
 
-pub static YOU_LOOSE_TEXT: &'static str = "you loose";
-pub static YOU_LOOSE_TEXT_COLOR: [f32, ..4] = RED;
-pub static YOU_LOOSE_POS: [f64, ..2] = [-0.55, 0.1];
+pub static YOU_LOSE_TEXT: &'static str = "you lose";
+pub static YOU_LOSE_TEXT_COLOR: [f32, ..4] = RED;
+pub static YOU_LOSE_POS: [f64, ..2] = [-0.55, 0.1];
 
 pub static AIR_BOTTLE_RADIUS: f64 = 0.1;
 pub static AIR_BOTTLE_TEST_COLOR: [f32, ..4] = WHITE;
@@ -38,7 +38,7 @@ pub static AIR_BOTTLE_POS: &'static [f64] = &[
     0.6, 8.8,
 ];
 
-pub static PLAYER_LOOSE_AIR_SPEED: f64 = 0.1;
+pub static PLAYER_LOSE_AIR_SPEED: f64 = 0.1;
 pub static PLAYER_COLOR: [f32, ..4] = [0.4, 0.4, 0.4, 1.0];
 pub static PLAYER_BITTEN_COLOR: [f32, ..4] = RED;
 pub static PLAYER_INITIAL_BLOOD: f64 = 1.0;

--- a/src/snakeapp.rs
+++ b/src/snakeapp.rs
@@ -56,12 +56,12 @@ impl SnakeApp {
                     .color(settings::YOU_WIN_TEXT_COLOR)
                 , gl);
             },
-            game_state::Loose => {
-                let pos = settings::YOU_LOOSE_POS;
-                text::text(settings::YOU_LOOSE_TEXT,
+            game_state::Lose => {
+                let pos = settings::YOU_LOSE_POS;
+                text::text(settings::YOU_LOSE_TEXT,
                     &text_c
                     .trans(pos[0], pos[1])
-                    .color(settings::YOU_LOOSE_TEXT_COLOR)
+                    .color(settings::YOU_LOSE_TEXT_COLOR)
                 , gl);
             },
             game_state::Play => {
@@ -79,7 +79,7 @@ impl SnakeApp {
         self.update_objects(dt);
         self.fill_air();
         self.win();
-        self.loose();
+        self.lose();
         self.show_blood();
         self.show_air();
         self.follow_player(dt);
@@ -139,7 +139,7 @@ impl SnakeApp {
     pub fn key_release(&mut self, key: keyboard::Key) {
         if key == keyboard::Return || key == keyboard::Space {
             match self.game_state.unwrap() {
-                game_state::Win | game_state::Loose => self.restart(),
+                game_state::Win | game_state::Lose => self.restart(),
                 _ => {},
             }
         }
@@ -241,11 +241,11 @@ impl SnakeApp {
         }
     }
 
-    fn loose(&mut self) {
+    fn lose(&mut self) {
         let blood = self.player_blood();
         let air = self.player_air();
         if blood < 0.0 || air < 0.0 {
-            self.game_state = Some(game_state::Loose);
+            self.game_state = Some(game_state::Lose);
             return;
         }
     }
@@ -272,7 +272,7 @@ impl SnakeApp {
 
         // Decrease the player's air with time.
         let air = self.player_air();
-        self.set_player_air(air - dt * settings::PLAYER_LOOSE_AIR_SPEED);
+        self.set_player_air(air - dt * settings::PLAYER_LOSE_AIR_SPEED);
     }
 
     fn player_pos(&self) -> [f64, ..2] {


### PR DESCRIPTION
Fixed loose typo throughout the project to the correct spelling, "lose".

Confirmed working with latest piston:

![loose_typo_fix](https://cloud.githubusercontent.com/assets/641547/3234223/7e60c582-f0c6-11e3-8836-08bedcf40622.png)
